### PR TITLE
Prep rename with org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Introduction
     :alt: Discord
 
 
-.. image:: https://github.com/circuitpython/CircuitPython_DisplayIO_SwitchRound/workflows/Build%20CI/badge.svg
-    :target: https://github.com/circuitpython/CircuitPython_DisplayIO_SwitchRound/actions
+.. image:: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_SwitchRound/workflows/Build%20CI/badge.svg
+    :target: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_SwitchRound/actions
     :alt: Build Status
 
 
@@ -73,7 +73,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/circuitpython/CircuitPython_DisplayIO_SwitchRound/blob/main/CODE_OF_CONDUCT.md>`_
+<https://github.com/circuitpython/CircuitPython_Org_DisplayIO_SwitchRound/blob/main/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Table of Contents
 .. toctree::
     :caption: Other Links
 
-    Download <https://github.com/circuitpython/CircuitPython_DisplayIO_SwitchRound/releases/latest>
+    Download <https://github.com/circuitpython/CircuitPython_Org_DisplayIO_SwitchRound/releases/latest>
     CircuitPython Reference Documentation <https://circuitpython.readthedocs.io>
     CircuitPython Support Forum <https://forums.adafruit.com/viewforum.php?f=60>
     Discord Chat <https://adafru.it/discord>

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     # The project's main homepage.
-    url="https://github.com/circuitpython/CircuitPython_DisplayIO_SwitchRound.git",
+    url="https://github.com/circuitpython/CircuitPython_Org_DisplayIO_SwitchRound.git",
     # Author details
     author="Kevin Matocha",
     author_email="",


### PR DESCRIPTION
these are the changes needed for changing the repository name to include Org. 

The repo should be renamed to `CircuitPython_Org_DisplayIO_SwitchRound` at the same time that this gets merged.