### PR TITLE
Remove max_size parameter

### DIFF
--- a/displayio_switchround.py
+++ b/displayio_switchround.py
@@ -139,10 +139,7 @@ class SwitchRound(Widget, Control):
         """"""  # Blocks documentation from super-class
 
         # initialize the Widget superclass (x, y, scale)
-        super().__init__(x=x, y=y, height=height, width=width, **kwargs, max_size=4)
-        # Define how many graphical elements will be in this group
-        # using "max_size=XX"
-        #
+        super().__init__(x=x, y=y, height=height, width=width, **kwargs)
         # Group elements for SwitchRound:
         #  0. switch_roundrect: The switch background
         #  1. switch_circle: The switch button

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -32,7 +32,7 @@ group to the display as in this example:
 .. code-block:: python
 
     my_switch = Switch(20, 30)  # create the switch at x=20, y=30
-    my_group = displayio.Group(max_size = 10)  # make a group that can hold 10 items
+    my_group = displayio.Group()  # make a group
     my_group.append(my_switch)  # Add my_switch to the group
 
     #

--- a/examples/displayio_switchround_multiple.py
+++ b/examples/displayio_switchround_multiple.py
@@ -91,7 +91,7 @@ my_switch8.anchored_position = (display.width - 10, display.height - 10)
 # the switch anchored_position is 10 pixels from the display
 # lower right corner
 
-my_group = displayio.Group(max_size=8)
+my_group = displayio.Group()
 my_group.append(my_switch)
 my_group.append(my_switch2)
 my_group.append(my_switch3)

--- a/examples/displayio_switchround_simpletest.py
+++ b/examples/displayio_switchround_simpletest.py
@@ -26,7 +26,7 @@ ts = adafruit_touchscreen.Touchscreen(
 my_switch = Switch(20, 30)
 
 
-my_group = displayio.Group(max_size=1)
+my_group = displayio.Group()
 my_group.append(my_switch)
 
 # Add my_group to the display


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Tested on a Pynt:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```